### PR TITLE
Rename MainActivity to RwMainActivity in Andriod Manifest plus readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # Roundware® for Android
 
-## Roundware® Overview
+## Roundware Overview
 
-Roundware® is a flexible distributed framework which collects, stores, organizes
+Roundware is a flexible distributed framework which collects, stores, organizes
 and re-presents audio content. Basically, it lets you collect audio from anyone
 with a smartphone or web access, upload it to a central repository along with
 its metadata and then filter it and play it back collectively in continuous
 audio streams.
 
 For more information about Roundware® functionality and projects that use the
-platform, please check out: [roundware.org](http://www.roundware.org "Roundware®")
+platform, please see: [roundware.org](http://www.roundware.org "Roundware")
 
-## Creating your own Roundware® Android App
+## Creating your own Roundware Android App
 
 ### Summary
-Your App and namespace wraps the available Roundware® App functionality allowing
-customization of existing Java Classes and Resources such as drawables and XML.
+Starting with a copy of the `starter-app` directory, your App wraps the
+available Roundware App functionality allowing customization of existing Java
+Classes and Resources such as drawables and XML.
+
 
 ### Getting Started
 
 Prerequisites:
-* A working Roundware® Server installation.
+* A working Roundware Server installation.
 * Knowledge of Android Mobile Application development with Android Studio
 
 Setup the codebase:
@@ -28,7 +30,7 @@ Setup the codebase:
 # Clone the codebase
 git clone https://github.com/roundware/roundware-android.git
 cd roundware-android
-# Copy the starter app
+# Copy "starter app" to "app"
 cp -R app-starter app
 cd app
 # Make your copy into a git repository
@@ -44,14 +46,40 @@ git push origin master
 Configure the project:
 
 * Open the project in Android Studio
-* Edit `app/AndroidManifest.xml` to set your namespace.
-* Edit `app/src/main/res/values/rwconfig.xml` to set your server and project ID. 
+* Edit `app/src/main/AndroidManifest.xml` to set your namespace. Change:
+  ```xml
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.roundware.app_starter">
+  ```
+
+  To:
+  ```xml
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.rw">
+  ```
+
+* Edit `app/build.gradle` to set your namespace. Change:
+  ```
+  defaultConfig {
+       applicationId "org.roundware.app_starter"
+  ```
+
+  To:
+  ```
+  defaultConfig {
+       applicationId "com.example.rw"
+  ```
+
+* Edit `app/src/main/res/values/rwconfig.xml` to set your server and project ID.
 * Edit `app/src/main/res/values/strings.xml` to set your application name.
 * Edit `app/src/main/res/values/api_keys.xml` to set your Google Maps API Key.
+* Run 'app' to try your new Roundware app with the provided configuration.
 
-Any files you copy from the `rwapp` and `rwservice` Modules into your `app`
-project will override the original versions during project build. Add the new
-values if the XML file already exists.
+### To infinity and beyond
 
-TODO: More details...
-
+* Any files you copy from the `rwapp` and `rwservice` modules into your `app`
+  project will override the original versions during project build.
+* Add the new values if the XML file already exists.
+* It should be possible to make the majority of needed changes without ever
+  modifying a file outside of the `app` directory. If not, please file an issue
+  on the issue queue.

--- a/app-starter/build.gradle
+++ b/app-starter/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "org.roundware.app_starter"
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }

--- a/app-starter/src/main/AndroidManifest.xml
+++ b/app-starter/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application android:label="@string/app_name"
         android:allowBackup="true">
-        <activity android:name=".MainActivity"
+        <activity android:name="org.roundware.rwapp.RwMainActivity"
             android:label="@string/app_name"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:screenOrientation="portrait">


### PR DESCRIPTION
The MainActivity was renamed in `rwapp` to RwMainActivity but that change wasn't updated in the `starter-app`. I've also used this opportunity to update the readme with more details and updated the Android SDK to 22 and build-tools to 22.0.1.
