### PR TITLE
Update for Android Studio 3.0 (stable) and other fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-beta7'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.google.gms:oss-licenses:0.9.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     repositories {
         jcenter()
-        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-beta7'
@@ -16,6 +15,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
     }
     dependencies {
@@ -13,8 +12,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
-        classpath 'com.google.gms:oss-licenses:0.9.1'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
     }
 }
 

--- a/rwapp/build.gradle
+++ b/rwapp/build.gradle
@@ -19,6 +19,7 @@ android {
 
 dependencies {
     compile project(':rwservice')
-    compile 'com.google.android.gms:play-services:6.5.87'
+    compile 'com.google.android.gms:play-services-location:11.4.2'
+    compile 'com.google.android.gms:play-services-maps:11.4.2'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/rwapp/build.gradle
+++ b/rwapp/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.google.gms.oss.licenses.plugin'
+
 
 android {
     compileSdkVersion 22
@@ -21,5 +23,6 @@ dependencies {
     compile project(':rwservice')
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
+    compile 'com.google.android.gms:play-services-oss-licenses:11.4.2'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/rwapp/build.gradle
+++ b/rwapp/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 22
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 21
+        minSdkVersion 14
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +20,5 @@ android {
 dependencies {
     compile project(':rwservice')
     compile 'com.google.android.gms:play-services:6.5.87'
-    compile 'com.squareup.picasso:picasso:2.4.0'
+    compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/rwapp/build.gradle
+++ b/rwapp/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.google.gms.oss.licenses.plugin'
-
 
 android {
     compileSdkVersion 22
@@ -23,6 +21,5 @@ dependencies {
     compile project(':rwservice')
     compile 'com.google.android.gms:play-services-location:11.4.2'
     compile 'com.google.android.gms:play-services-maps:11.4.2'
-    compile 'com.google.android.gms:play-services-oss-licenses:11.4.2'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/rwapp/src/main/AndroidManifest.xml
+++ b/rwapp/src/main/AndroidManifest.xml
@@ -64,14 +64,6 @@
             android:theme="@style/AppTheme" >
         </activity>
 
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
-
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
-
         <service android:label="RoundwareService" android:name="org.roundware.service.RWService">
             <meta-data android:name="com.google.android.gms.version" android:value="3265130" />
         </service>

--- a/rwapp/src/main/AndroidManifest.xml
+++ b/rwapp/src/main/AndroidManifest.xml
@@ -64,6 +64,13 @@
             android:theme="@style/AppTheme" >
         </activity>
 
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
+
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
 
         <service android:label="RoundwareService" android:name="org.roundware.service.RWService">
             <meta-data android:name="com.google.android.gms.version" android:value="3265130" />

--- a/rwapp/src/main/java/org/roundware/rwapp/RwBoundActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwBoundActivity.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.os.IBinder;
+import android.support.v7.app.AppCompatActivity;
 
 import org.roundware.service.RW;
 import org.roundware.service.RWService;

--- a/rwapp/src/main/java/org/roundware/rwapp/RwBoundActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwBoundActivity.java
@@ -12,7 +12,6 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.os.IBinder;
-import android.support.v7.app.AppCompatActivity;
 
 import org.roundware.service.RW;
 import org.roundware.service.RWService;

--- a/rwapp/src/main/java/org/roundware/rwapp/RwListenActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwListenActivity.java
@@ -79,7 +79,6 @@ public class RwListenActivity extends RwBoundActivity {
     private AssetData mPendingAsset = new AssetData(null,null);
     private AssetData mCurrentAsset = mPendingAsset;
 
-
     private PausableScheduledThreadPoolExecutor mEventPool;
 
     private final Object mAssetImageLock = new Object();

--- a/rwapp/src/main/java/org/roundware/rwapp/RwMainActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwMainActivity.java
@@ -14,17 +14,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -33,9 +30,6 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.Toast;
 import android.widget.ViewFlipper;
-
-import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
 
 import org.roundware.rwapp.utils.AssetImageManager;
 import org.roundware.rwapp.utils.ClassRegistry;
@@ -238,7 +232,7 @@ public class RwMainActivity extends RwBoundActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case MENU_ITEM_INFO: {
-                showVersionDialog(true);
+                showVersionAndLicensesInfoDialog(true);
                 return true;
             }
             case MENU_ITEM_PREFERENCES: {
@@ -472,9 +466,8 @@ public class RwMainActivity extends RwBoundActivity {
      *
      * @param forced true to always display the dialog
      */
-    private void showVersionDialog(boolean forced) {
-        Intent intent = new Intent(this, OssLicensesMenuActivity.class);
-        startActivity(intent);
+    private void showVersionAndLicensesInfoDialog(boolean forced) {
+        showMessage(getString(R.string.version_and_licenses_text), false, false);
     }
 
 

--- a/rwapp/src/main/java/org/roundware/rwapp/RwMainActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwMainActivity.java
@@ -464,15 +464,17 @@ public class RwMainActivity extends RwBoundActivity{
      * @param forced true to always display the dialog
      */
     private void showVersionDialog(boolean forced) {
+        // FIX: no dialog being displayed
+        // FIX: See https://developers.google.com/android/guides/opensource for new guidelines
         try {
             StringBuilder license = new StringBuilder();
             license.append(getResources().getString(R.string.version_text));
-            String osLicense = GooglePlayServicesUtil.getOpenSourceSoftwareLicenseInfo(getApplicationContext());
-            if (osLicense != null) {
-                license.append(osLicense);
-            } else {
-                license.append(R.string.play_services_not_installed);
-            }
+//            String osLicense = GooglePlayServicesUtil.getOpenSourceSoftwareLicenseInfo(getApplicationContext());
+//            if (osLicense != null) {
+//                license.append(osLicense);
+//            } else {
+//                license.append(R.string.play_services_not_installed);
+//            }
         } catch (Exception e) {
             Log.e(LOGTAG, "Unable to show version dialog!", e);
         }

--- a/rwapp/src/main/java/org/roundware/rwapp/RwSpeakActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwSpeakActivity.java
@@ -41,6 +41,7 @@ import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MarkerOptions;
 
@@ -350,19 +351,18 @@ public class RwSpeakActivity extends RwBoundActivity {
 
     private void initMapIfNeeded() {
         if (mGoogleMap == null) {
-            mGoogleMap = mMapView.getMap();
-            if (mGoogleMap != null) {
-                setUpMap();
-            }
+            mMapView.getMapAsync(new OnMapReadyCallback() {
+                @Override
+                public void onMapReady(GoogleMap googleMap) {
+                    mGoogleMap = googleMap;
+                    mGoogleMap.getUiSettings().setMyLocationButtonEnabled(false);
+                    mGoogleMap.getUiSettings().setZoomControlsEnabled(false);
+                    mGoogleMap.getUiSettings().setAllGesturesEnabled(true);
+                    mGoogleMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE);
+                    mGoogleMap.setMyLocationEnabled(false);
+                }
+            });
         }
-    }
-
-    private void setUpMap() {
-        mGoogleMap.getUiSettings().setMyLocationButtonEnabled(false);
-        mGoogleMap.getUiSettings().setZoomControlsEnabled(false);
-        mGoogleMap.getUiSettings().setAllGesturesEnabled(true);
-        mGoogleMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE);
-        mGoogleMap.setMyLocationEnabled(false);
     }
 
 

--- a/rwapp/src/main/res/values/strings.xml
+++ b/rwapp/src/main/res/values/strings.xml
@@ -49,12 +49,12 @@
 
 <string name="play_services_not_installed">Google Play services is not installed on this device.</string>
 
-<!-- version info (Android open source license text will be appended) -->
-<string name="version_text">
-    \n
-    \nThis app was made using the open-source Roundware media platform, see
-    \nhttp://www.roundware.org for more information.
-    \n
+<!-- info text about app version and used open source licenses -->
+<string name="version_and_licenses_text">
+    \nThis app is built on the open-source Roundware audio augmented
+    reality platform (roundware.org). It also makes use
+    of Google Maps, Google Play Services and the Picasso image
+    library (by Square, Inc.).
     \n
 </string>
 

--- a/rwapp/src/main/res/values/styles.xml
+++ b/rwapp/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Black.NoTitleBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to

--- a/rwservice/build.gradle
+++ b/rwservice/build.gradle
@@ -20,4 +20,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile 'com.android.support:support-v4:22.2.1'
+    compile 'com.android.support:appcompat-v7:22.2.1'
 }

--- a/rwservice/build.gradle
+++ b/rwservice/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 22
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 21
+        minSdkVersion 14
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
@@ -20,6 +19,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.android.support:support-v4:21.0.0'
+    compile 'com.android.support:support-v4:22.2.1'
 }
-

--- a/rwservice/build.gradle
+++ b/rwservice/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.google.gms.oss.licenses.plugin'
 
 android {
     compileSdkVersion 22

--- a/rwservice/build.gradle
+++ b/rwservice/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.google.gms.oss.licenses.plugin'
 
 android {
     compileSdkVersion 22

--- a/rwservice/src/main/java/org/roundware/service/RWService.java
+++ b/rwservice/src/main/java/org/roundware/service/RWService.java
@@ -1666,7 +1666,7 @@ import java.util.TimerTask;
                 key = getString(R.string.rw_key_server_error_traceback);
                 break;
             case USER:
-                key = getString(R.string.rw_key_server_result);
+                key = getString(R.string.rw_key_server_user_message);
                 break;
             case SHARING:
                 key = getString(R.string.rw_key_server_sharing_message);

--- a/rwservice/src/main/java/org/roundware/service/RWService.java
+++ b/rwservice/src/main/java/org/roundware/service/RWService.java
@@ -148,6 +148,7 @@ import java.util.TimerTask;
     private boolean mShowDetailedMessages = false;
     private boolean mStartPlayingWhenReady = false;
     private boolean mOnlyConnectOverWiFi = false;
+    private String mPreviousUserMessage = "";
     private int mVolumeLevel = 0;
     private int mMinVolumeLevel = 0;
     private int mMaxVolumeLevel = 50;
@@ -1716,10 +1717,11 @@ import java.util.TimerTask;
         String message;
         Intent intent = new Intent();
         
-        // process none critical messages first
+        // process none critical messages first (and do not send duplicate messages)
 
         message = retrieveServerMessage(ServerMessageType.USER, response);
-        if (message != null) {
+        if ((message != null) && (!message.equalsIgnoreCase(mPreviousUserMessage))) {
+            mPreviousUserMessage = message;
             intent.setAction(RW.USER_MESSAGE);
             intent.putExtra(RW.EXTRA_SERVER_MESSAGE, message);
             if (D) {

--- a/rwservice/src/main/res/values/rwconfig.xml
+++ b/rwservice/src/main/res/values/rwconfig.xml
@@ -91,7 +91,7 @@
     <string name="rw_key_server_error_number">error_number</string>
     <string name="rw_key_server_error_message">error_message</string>
     <string name="rw_key_server_error_traceback">traceback</string>
-    <string name="rw_key_server_user_message">user_error_message</string>
+    <string name="rw_key_server_user_message">user_message</string>
     <string name="rw_key_server_sharing_message">sharing_message</string>
     
     <string name="rw_key_server_asset_id">asset_id</string>


### PR DESCRIPTION
This one is actually for Android Studio 3 RC 1.

Fixes a few more things, including displaying the open source licenses notice and handling the out-of-range server message properly. Also upgrades to the latest Google Play Services with async Google Maps calls.

TargetSDK is set to a maximum of 22. Setting it to a higher SDK version will require implementing run time permissions checking, instead of the older install time checking. Something to be done in the future. Using a higher SDK might also affect what Android allows regarding background processing, which the framework does to send pings and calls to the Roundware server.

There is still a possible issue with the web views (filters for Listen and Speak) not being displayed full screen when they are opened multiple times. The first time they usually display ok. Next time they might not be full screen (in width). Might be an issue with the Android emulator but should be investigated.