### PR TITLE
Permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.2.30'
     repositories {
         google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
+apply plugin: 'kotlin'
 
 allprojects {
     repositories {
@@ -18,6 +22,22 @@ allprojects {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         }
+    }
+}
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 18 13:45:42 CEST 2017
+#Fri Aug 03 08:39:17 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/rwapp/build.gradle
+++ b/rwapp/build.gradle
@@ -1,11 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-
+    compileSdkVersion 27
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -15,11 +14,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildToolsVersion '28.0.1'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     compile project(':rwservice')
-    compile 'com.google.android.gms:play-services-location:11.4.2'
-    compile 'com.google.android.gms:play-services-maps:11.4.2'
-    compile 'com.squareup.picasso:picasso:2.5.2'
+    compile 'com.google.android.gms:play-services-location:15.0.1'
+    compile 'com.google.android.gms:play-services-maps:15.0.1'
+    compile 'com.squareup.picasso:picasso:2.71828'
 }

--- a/rwapp/src/main/java/org/roundware/rwapp/RwListenActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwListenActivity.java
@@ -422,7 +422,7 @@ public class RwListenActivity extends RwBoundActivity {
 
         if (!TextUtils.isEmpty(url)) {
             //pre-load into cache
-            Picasso.with(this).load(url);
+            Picasso.get().load(url);
         }
     }
 
@@ -470,7 +470,7 @@ public class RwListenActivity extends RwBoundActivity {
             mAssetTextView.setText(mCurrentAsset.description);
             if (showUrl) {
                 //load
-                Picasso picasso = Picasso.with(this);
+                Picasso picasso = Picasso.get();
                 // set below true, to view image source debugging
                 picasso.setIndicatorsEnabled(false);
                 picasso.load(mCurrentAsset.url)
@@ -486,8 +486,8 @@ public class RwListenActivity extends RwBoundActivity {
                             }
 
                             @Override
-                            public void onError() {
-                                Log.w(LOGTAG, "Image load failure!");
+                            public void onError(Exception e) {
+                                Log.w(LOGTAG, "Image load failure! " + e.getMessage());
                                 mAssetImageLayout.setVisibility(View.INVISIBLE);
                             }
                         });

--- a/rwapp/src/main/java/org/roundware/rwapp/RwMainActivity.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/RwMainActivity.java
@@ -4,6 +4,7 @@
  */
 package org.roundware.rwapp;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -64,6 +65,31 @@ public class RwMainActivity extends RwBoundActivity {
     private ProgressDialog mProgressDialog;
     private Intent mRwServiceIntent;
     private boolean mIsConnected;
+
+    private int PERMISSION_ALL_SPEAK = 1;
+    private int PERMISSION_ALL_LISTEN = 2;
+    String[] PERMISSIONS_SPEAK = {
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION
+    };
+    String[] PERMISSIONS_LISTEN = {
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION
+    };
+
+    public static boolean hasPermissions(Context context, String... permissions) {
+        if (context != null && permissions != null) {
+            for (String permission : permissions) {
+                if (ActivityCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 
     /**
      * Handles connection state to an RWService Android Service. In this
@@ -343,6 +369,9 @@ public class RwMainActivity extends RwBoundActivity {
         mListenButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if(!hasPermissions(this, PERMISSIONS_SPEAK)){
+                    ActivityCompat.requestPermissions(this, PERMISSIONS_SPEAK, PERMISSION_ALL_SPEAK);
+                }
                 startActivity(new Intent(getApplicationContext(), ClassRegistry.get("RwListenActivity")));
             }
         });

--- a/rwapp/src/main/java/org/roundware/rwapp/utils/Utils.java
+++ b/rwapp/src/main/java/org/roundware/rwapp/utils/Utils.java
@@ -10,6 +10,8 @@ import android.app.AlertDialog.Builder;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.pm.PackageManager;
+import android.support.v4.content.ContextCompat;
 
 import org.roundware.rwapp.R;
 
@@ -32,6 +34,8 @@ public class Utils {
     public static void showMessageDialog(final Activity activity, String message, final boolean isError, final boolean isFatal) {
         Builder alertBox;
         alertBox = new AlertDialog.Builder(activity);
+        alertBox.setCancelable(false);
+
         if (isError) {
             alertBox.setTitle(R.string.error_title);
         } else {
@@ -59,6 +63,49 @@ public class Utils {
 
 
     /**
+     * Checks if all the listed permissions have been granted by the user.
+     *
+     * @param context that should be checked for allowed permissions
+     * @param permissions list of permissions to check
+     * @return false if not all permissions have been granted by the user
+     */
+    public static boolean hasPermissions(Context context, String... permissions) {
+        if (context != null && permissions != null) {
+            for (String permission : permissions) {
+                if (ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Checks results of onRequestPermissionsResult to see if all requested
+     * permissions have been granted by the user.
+     *
+     * @param permissions that were requested
+     * @param grantResults for the corresponding permissions (PERMISSION_GRANTED, PERMISSION_DENIED)
+     * @return false if one of the permissions was denied
+     */
+    public static boolean areAllPermissionsGranted(String permissions[], int grantResults[]) {
+        // check if all permissions where granted
+        boolean allGranted = false;
+        if (grantResults.length > 0) {
+            allGranted = true;
+            for (int grantResult : grantResults) {
+                if (grantResult == PackageManager.PERMISSION_DENIED) {
+                    allGranted = false;
+                    break;
+                }
+            }
+        }
+        return allGranted;
+    }
+
+
+    /**
      * Shows a standardized progress dialog based on the specified parameters.
      *
      * @param c Context to reference
@@ -68,7 +115,7 @@ public class Utils {
      * @param cancelable setting for the new progress dialog
      * @return the ProgressDialog displayed
      */
-    //FIXME this leaks windows!
+    // FIXME this leaks windows!
     public static ProgressDialog showProgressDialog(Context c, String title, String message, boolean indeterminate, boolean cancelable) {
         return ProgressDialog.show(c, title, message, indeterminate, cancelable);
     }

--- a/rwapp/src/main/res/values/strings.xml
+++ b/rwapp/src/main/res/values/strings.xml
@@ -58,6 +58,22 @@
     \n
 </string>
 
+<!-- info text when user denies one or more critical permissions for app functionality -->
+<string name="permissions_for_location_denied">
+    \nThis app is location based, and really needs to be
+    able to figure out where you are in the world to work properly.
+    Please start again and grant the requested permissions. Thank you!
+    \n
+</string>
+
+<string name="permissions_for_recording_denied">
+    \nThe requested permissions are needed so the app can make
+    a recording of your voice and store it locally before it will
+    be transmitted to our servers. Please try again and grant the
+    requested permissions. Thank you!
+    \n
+</string>
+
 <!-- dialog messages -->
 <string name="unable_to_retrieve_configuration">
     Unable to load project configuration from server or

--- a/rwservice/build.gradle
+++ b/rwservice/build.gradle
@@ -1,24 +1,29 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-
+    compileSdkVersion 27
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
+    useLibrary 'org.apache.http.legacy'
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildToolsVersion '28.0.1'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile fileTree(include: '*.jar', dir: 'libs')
+    compile 'com.android.support:support-v4:27.1.1'
+    compile 'com.android.support:appcompat-v7:27.1.1'
 }


### PR DESCRIPTION
Changes to version numbers all around, using Android Studio 3.1.3.

Update for runtime permission checking needed for Android >= 6. RWMainActivity checks for location permissions, RWSpeakActivity for recording related permissions. Updated RWService to more gracefully handle missing (location) permissions and not cause the app to crash.

Added two texts to the strings.xml resource file that are used in message dialogs when the user doesn't grant one of the required permissions and either the app can not start, or a recording can not be made. You can change those or overwrite in your custom app.
